### PR TITLE
fix: make Stripe billing portal return URL configurable

### DIFF
--- a/docker/docker-compose.dokploy.yml
+++ b/docker/docker-compose.dokploy.yml
@@ -58,7 +58,7 @@ services:
       SCREENSHOT_MAX_HEIGHT: ${SCREENSHOT_MAX_HEIGHT:-1080}
       SCREENSHOT_DEFAULT_TIMEOUT: ${SCREENSHOT_DEFAULT_TIMEOUT:-30000}
       SCREENSHOT_MAX_TIMEOUT: ${SCREENSHOT_MAX_TIMEOUT:-60000}
-      
+
       # Retry scheduler configuration
       # Set to false to disable automatic retry processing (useful for debugging)
       RETRY_SCHEDULER_ENABLED: ${RETRY_SCHEDULER_ENABLED:-true}
@@ -72,12 +72,13 @@ services:
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
       STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
+      BILLING_PORTAL_RETURN_URL: ${BILLING_PORTAL_RETURN_URL:-http://localhost:3000/billing}
 
       # Clerk authentication
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY}
       CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY}
       CLERK_DOMAIN: ${CLERK_DOMAIN}
-      
+
       # Auth provider configuration (CRITICAL for AuthProviderFactory)
       DEFAULT_AUTH_PROVIDER: ${DEFAULT_AUTH_PROVIDER:-local}
       ENABLED_AUTH_PROVIDERS: ${ENABLED_AUTH_PROVIDERS:-local}

--- a/src/main/kotlin/dev/screenshotapi/infrastructure/adapters/input/rest/BillingController.kt
+++ b/src/main/kotlin/dev/screenshotapi/infrastructure/adapters/input/rest/BillingController.kt
@@ -5,9 +5,9 @@ import dev.screenshotapi.core.domain.exceptions.ValidationException
 import dev.screenshotapi.core.usecases.billing.*
 import dev.screenshotapi.infrastructure.adapters.input.rest.dto.*
 import dev.screenshotapi.infrastructure.auth.requireUserId
+import dev.screenshotapi.infrastructure.config.AppConfig
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.auth.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import org.jetbrains.exposed.exceptions.ExposedSQLException
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory
  */
 class BillingController : KoinComponent {
     private val logger = LoggerFactory.getLogger(BillingController::class.java)
+    private val config: AppConfig by inject()
     private val getAvailablePlansUseCase: GetAvailablePlansUseCase by inject()
     private val createCheckoutSessionUseCase: CreateCheckoutSessionUseCase by inject()
     private val getUserSubscriptionUseCase: GetUserSubscriptionUseCase by inject()
@@ -115,7 +116,7 @@ class BillingController : KoinComponent {
             // Execute use case to create billing portal session
             val request = CreateBillingPortalSessionRequest(
                 userId = userId,
-                returnUrl = "http://localhost:3000/billing" // TODO: Make this configurable
+                returnUrl = config.billing.billingPortalReturnUrl
             )
 
             val response = createBillingPortalSessionUseCase(request)

--- a/src/main/kotlin/dev/screenshotapi/infrastructure/config/BillingConfig.kt
+++ b/src/main/kotlin/dev/screenshotapi/infrastructure/config/BillingConfig.kt
@@ -7,12 +7,15 @@ package dev.screenshotapi.infrastructure.config
 data class BillingConfig(
     val stripe: StripeConfig,
     val defaultPaymentProvider: String = "stripe",
-    val enabledPaymentProviders: List<String> = listOf("stripe")
+    val enabledPaymentProviders: List<String> = listOf("stripe"),
+    val billingPortalReturnUrl: String
 ) {
     companion object {
         fun load(): BillingConfig {
             return BillingConfig(
-                stripe = StripeConfig.load()
+                stripe = StripeConfig.load(),
+                billingPortalReturnUrl = System.getenv("BILLING_PORTAL_RETURN_URL") 
+                    ?: "http://localhost:3000/billing"
             )
         }
     }


### PR DESCRIPTION
## Summary
Replace hardcoded billing portal URL with environment variable (BILLING_PORTAL_RETURN_URL)