### PR TITLE
  feat: add planLimit to user usage response for accurate billing calculations

### DIFF
--- a/src/main/kotlin/dev/screenshotapi/infrastructure/adapters/input/rest/dto/AuthDtos.kt
+++ b/src/main/kotlin/dev/screenshotapi/infrastructure/adapters/input/rest/dto/AuthDtos.kt
@@ -110,6 +110,7 @@ data class UserUsageResponseDto(
     val totalScreenshots: Long,
     val screenshotsLast30Days: Long,
     val planId: String,
+    val planLimit: Int,
     val currentPeriodStart: String,
     val currentPeriodEnd: String
 )
@@ -198,6 +199,7 @@ fun dev.screenshotapi.core.usecases.auth.GetUserUsageResponse.toDto(): UserUsage
     totalScreenshots = totalScreenshots,
     screenshotsLast30Days = screenshotsLast30Days,
     planId = planId,
+    planLimit = planLimit,
     currentPeriodStart = currentPeriodStart.toString(),
     currentPeriodEnd = currentPeriodEnd.toString()
 )

--- a/src/main/kotlin/dev/screenshotapi/infrastructure/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/dev/screenshotapi/infrastructure/plugins/DependencyInjection.kt
@@ -183,7 +183,7 @@ fun useCaseModule() = module {
     single { AuthenticateUserUseCase(get<UserRepository>()) }
     single { RegisterUserUseCase(get<UserRepository>(), get<PlanRepository>()) }
     single { GetUserProfileUseCase(get<UserRepository>()) }
-    single { GetUserUsageUseCase(get<UserRepository>(), get<ScreenshotRepository>()) }
+    single { GetUserUsageUseCase(get<UserRepository>(), get<ScreenshotRepository>(), get<PlanRepository>()) }
     single { GetUserUsageTimelineUseCase(get<UsageRepository>(), get<UserRepository>()) }
     single { UpdateUserProfileUseCase(get<UserRepository>()) }
 


### PR DESCRIPTION
  ## Summary
  - ✅ Add `planLimit` field to user usage API response
  - ✅ Enable accurate usage percentage calculations in frontend
  - ✅ Replace hardcoded plan limits with real subscription data

  ## Changes Made
  - **Updated `GetUserUsageUseCase`**: Added `PlanRepository` dependency to fetch plan limits
  - **Enhanced DTOs**: Added `planLimit: Int` field to `GetUserUsageResponse` and `UserUsageResponseDto`
  - **Dependency Injection**: Modified Koin configuration to provide `PlanRepository` to the use case
  - **Type Safety**: Maintained clean architecture with proper dependency injection

  ## Technical Details
  ```kotlin
  // Before: Only user and screenshot data
  class GetUserUsageUseCase(
      private val userRepository: UserRepository,
      private val screenshotRepository: ScreenshotRepository
  )

  // After: Now includes plan repository for limits
  class GetUserUsageUseCase(
      private val userRepository: UserRepository,
      private val screenshotRepository: ScreenshotRepository,
      private val planRepository: PlanRepository
  )

  API Response Enhancement

  {
    "userId": "user123",
    "creditsRemaining": 50,
    "planLimit": 2000,  // ← NEW: Real plan limit from database
    "planId": "pro",
    "totalScreenshots": 1950,
    // ... other fields
  }
```